### PR TITLE
Allow subclassing of MDCOutlinedTextField

### DIFF
--- a/Sources/include/MDCOutlinedTextField.h
+++ b/Sources/include/MDCOutlinedTextField.h
@@ -19,7 +19,6 @@
 /**
  An implementation of a Material outlined text field.
  */
-__attribute__((objc_subclassing_restricted))
 @interface MDCOutlinedTextField : MDCBaseTextField
 
 /**


### PR DESCRIPTION
Necessary for a subclass that disables copy/cut